### PR TITLE
Report star count in generated json

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -41,7 +41,8 @@ for repo in repos:
             "last_update": int(repo.updated_at.timestamp() * 1000),
             "prop_url": f"https://raw.githubusercontent.com/{repo.full_name}/{repo.default_branch}/module.prop",
             "zip_url": f"https://github.com/{repo.full_name}/archive/{repo.default_branch}.zip",
-            "notes_url": f"https://raw.githubusercontent.com/{repo.full_name}/{repo.default_branch}/README.md"
+            "notes_url": f"https://raw.githubusercontent.com/{repo.full_name}/{repo.default_branch}/README.md",
+            "stars": int(repo.stargazers_count)
         }
 
         # Append to skeleton


### PR DESCRIPTION
Documentation: https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.stargazers_count

This is for future integration of stars count in Fox's Magisk Module Manager.