### PR TITLE
Prevent `last_update` by repos actions

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -2,14 +2,17 @@ import sys
 import json
 import os
 from github import Github
+from datetime import datetime
 
 # Configuration
 REPO_NAME = "Magisk-Modules-Alt-Repo"
 REPO_TITLE = "Magisk Modules Alt Repo"
+REPO_SUBMIT = "https://github.com/Magisk-Modules-Alt-Repo/submission"
 
 # Skeleton for the repository
 meta = {
     "name": REPO_TITLE,
+    "submitModule": REPO_SUBMIT,
     "last_update": "",
     "modules": []
 }
@@ -35,10 +38,19 @@ for repo in repos:
             lhs, rhs = line.split("=", 1)
             moduleprop[lhs] = rhs
         
+        # Get the last update timestamp of the module.prop file
+        last_update_timestamp = repo.get_contents("module.prop").last_modified
+
+        # Convert the string to a datetime object
+        last_update_datetime = datetime.strptime(last_update_timestamp, '%a, %d %b %Y %H:%M:%S %Z')
+
+        # Get the timestamp of the last update
+        last_update_timestamp = datetime.timestamp(last_update_datetime)
+
         # Create meta module information
         module = {
             "id": moduleprop["id"],
-            "last_update": int(repo.updated_at.timestamp() * 1000),
+            "last_update": int(last_update_timestamp * 1000),
             "prop_url": f"https://raw.githubusercontent.com/{repo.full_name}/{repo.default_branch}/module.prop",
             "zip_url": f"https://github.com/{repo.full_name}/archive/{repo.default_branch}.zip",
             "notes_url": f"https://raw.githubusercontent.com/{repo.full_name}/{repo.default_branch}/README.md",


### PR DESCRIPTION
Prevent repo `last_update` by  using `last_modified` of the `module.prop`. It causes that managers can't sort modules by date (oldest/newest) in the right way. The method doesn't count repo update such as added stars, forks etc.